### PR TITLE
Found a mismatch in the default directories

### DIFF
--- a/files/pe_nc_backup
+++ b/files/pe_nc_backup
@@ -29,8 +29,8 @@ failures = 0
 thefile  = 'node_groups.json'
 
 unless my_dir && my_dir != ''
-  puts "No backup directory specified, using /pe_nc_backup"
-  my_dir = '/pe_nc_backup'
+  puts "No backup directory specified, using /opt/pe_nc_backup"
+  my_dir = '/opt/pe_nc_backup'
 end
 
 unless File.directory?(my_dir)


### PR DESCRIPTION
Minor issue, but if the backup script is called outside of the cron job with the default values, it'll fail with 

```
21:19 # /opt/pe_nc_backup/bin/pe_nc_backup
No backup directory specified, using /pe_nc_backup
Traceback (most recent call last):
/opt/pe_nc_backup/bin/pe_nc_backup:37:in `<main>': Directory does not exist at /pe_nc_backup (RuntimeError)
```

The manifest sets the default. to `/opt/pe_nc_backup`