### PR TITLE
Improve verbosity controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,9 @@ Parameters:
 
 - `path` - path to directory to store the backup git repo, backup script, and log file. Default: `/opt/pe_nc_backup/`. The parent directory must already exist.
 - `ssl_dir` - The path to the Puppet Agent's ssl directory on the master. Default: `/etc/puppetlabs/puppet/ssl`.
+- `log_level` - The verbosity of the Ruby logger writing to the log file. Possible values: 'debug', 'info', 'warn', 'error', 'fatal'. Default: `info`.
+- `log_level_stdout` - The verbosity of the Ruby logger writing to STDOUT. Possible values: 'debug', 'info', 'warn', 'error', 'fatal'. Default: `error`.
+- `stdout_log` - Whether to enable the STDOUT logger. Default: true (Boolean)
 
 ## Limitations
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -9,8 +9,8 @@
 class pe_nc_backup (
   String                                          $path             = '/opt/pe_nc_backup',
   String                                          $ssl_dir          = '/etc/puppetlabs/puppet/ssl',
-  Enum['debug', 'info', 'warn', 'error', 'fatal'] $log_level        = 'error',
-  Enum['debug', 'info', 'warn', 'error', 'fatal'] $log_level_stdout = 'info',
+  Enum['debug', 'info', 'warn', 'error', 'fatal'] $log_level        = 'info',
+  Enum['debug', 'info', 'warn', 'error', 'fatal'] $log_level_stdout = 'error',
   Boolean                                         $stdout_log       = true,
 ) {
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -7,8 +7,10 @@
 # @example
 #   include pe_nc_backup
 class pe_nc_backup (
-  String $path    = '/opt/pe_nc_backup',
-  String $ssl_dir = '/etc/puppetlabs/puppet/ssl',
+  String                                          $path       = '/opt/pe_nc_backup',
+  String                                          $ssl_dir    = '/etc/puppetlabs/puppet/ssl',
+  Enum['debug', 'info', 'warn', 'error', 'fatal'] $log_level  = 'error',
+  Boolean                                         $stdout_log = true,
 ) {
 
   $git_repo_dir = "${path}/repo"
@@ -44,7 +46,11 @@ class pe_nc_backup (
     ensure  => file,
     path    => "${bin_dir}/pe_nc_backup",
     mode    => '0755',
-    content => epp('pe_nc_backup/pe_nc_backup.epp', { ssl_dir => $ssl_dir })
+    content => epp('pe_nc_backup/pe_nc_backup.epp', {
+      ssl_dir    => $ssl_dir,
+      log_level  => $log_level,
+      stdout_log => $stdout_log,
+    })
   }
 
   # sudo -H -u pe-puppet /opt/puppetlabs/puppet/bin/ncio backup > /var/tmp/backup.json

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -7,10 +7,11 @@
 # @example
 #   include pe_nc_backup
 class pe_nc_backup (
-  String                                          $path       = '/opt/pe_nc_backup',
-  String                                          $ssl_dir    = '/etc/puppetlabs/puppet/ssl',
-  Enum['debug', 'info', 'warn', 'error', 'fatal'] $log_level  = 'error',
-  Boolean                                         $stdout_log = true,
+  String                                          $path             = '/opt/pe_nc_backup',
+  String                                          $ssl_dir          = '/etc/puppetlabs/puppet/ssl',
+  Enum['debug', 'info', 'warn', 'error', 'fatal'] $log_level        = 'error',
+  Enum['debug', 'info', 'warn', 'error', 'fatal'] $log_level_stdout = 'info',
+  Boolean                                         $stdout_log       = true,
 ) {
 
   $git_repo_dir = "${path}/repo"
@@ -47,9 +48,10 @@ class pe_nc_backup (
     path    => "${bin_dir}/pe_nc_backup",
     mode    => '0755',
     content => epp('pe_nc_backup/pe_nc_backup.epp', {
-      ssl_dir    => $ssl_dir,
-      log_level  => $log_level,
-      stdout_log => $stdout_log,
+      ssl_dir          => $ssl_dir,
+      log_level        => $log_level,
+      log_level_stdout => $log_level_stdout,
+      stdout_log       => $stdout_log,
     })
   }
 

--- a/templates/pe_nc_backup.epp
+++ b/templates/pe_nc_backup.epp
@@ -28,10 +28,13 @@ end
 puppet_bindir = '/opt/puppetlabs/puppet/bin'
 ssldir        = '<%= $ssl_dir -%>'
 
-my_dir     = ARGV[0]
-certname   = ARGV[1] || `#{puppet_bindir}/puppet config print certname`.chomp
-log_level  = ARGV[2] || '<%= $log_level %>'
-stdout_log = <%= $stdout_log %>
+my_dir   = ARGV[0]
+certname = ARGV[1] || `#{puppet_bindir}/puppet config print certname`.chomp
+
+log_level        = '<%= $log_level %>'
+log_level_stdout = '<%= $log_level_stdout %>'
+stdout_log       = <%= $stdout_log %>
+
 failures  = 0
 thefile   = 'node_groups.json'
 
@@ -49,7 +52,7 @@ logger = Logger.new(logfile, 10, 1_024_000)
 logger.level = log_level
 
 logger_stdout = Logger.new(STDOUT)
-logger_stdout.level = log_level
+logger_stdout.level = log_level_stdout
 loggers = [logger]
 loggers << logger_stdout if stdout_log
 

--- a/templates/pe_nc_backup.epp
+++ b/templates/pe_nc_backup.epp
@@ -65,9 +65,22 @@ timestamp = Time.now.iso8601
 
 log(loggers, :info, "determined certname to be: #{certname}")
 
+agent_cert = "#{ssldir}/certs/#{certname}.pem"
+agent_key = "#{ssldir}/private_keys/#{certname}.pem"
+
+unless File.file?(agent_cert)
+  log(loggers, :error, "certificate file not found at #{agent_cert}")
+  exit 1
+end
+
+unless File.file?(agent_key)
+  log(loggers, :error, "key file not found at #{agent_key}")
+  exit 1
+end
+
 cmd = "#{puppet_bindir}/ncio --uri 'https://#{certname}:4433/classifier-api/v1' "
-cmd += "--cert '#{ssldir}/certs/#{certname}.pem' "
-cmd += "--key '#{ssldir}/private_keys/#{certname}.pem' "
+cmd += "--cert '#{agent_cert}' "
+cmd += "--key '#{agent_key}' "
 cmd += "backup > '#{repo_dir}/#{thefile}'"
 
 log(loggers, :info, "Running command: [#{cmd}]")

--- a/templates/pe_nc_backup.epp
+++ b/templates/pe_nc_backup.epp
@@ -31,7 +31,7 @@ ssldir        = '<%= $ssl_dir -%>'
 my_dir     = ARGV[0]
 certname   = ARGV[1] || `#{puppet_bindir}/puppet config print certname`.chomp
 log_level  = ARGV[2] || '<%= $log_level %>'
-stdout_log = (ARGV[3] == 'stdout_log') || <%= $stdout_log %>
+stdout_log = <%= $stdout_log %>
 failures  = 0
 thefile   = 'node_groups.json'
 
@@ -92,7 +92,7 @@ end
 
 Dir.chdir(repo_dir)
 
-if system('git status --porcelain')
+if system('git status --porcelain > /dev/null')
   if failures.zero?
 
     # TODO: if the origin remote exists, try a pull from it (errors are non-fatal)
@@ -103,7 +103,7 @@ if system('git status --porcelain')
     end
 
     if `git status --porcelain #{thefile}` =~ %r{^\s*[AM]}
-      unless system("git commit -m 'Update node groups by pe_nc_backup on #{certname} at #{timestamp}'")
+      unless system("git commit --quiet -m 'Update node groups by pe_nc_backup on #{certname} at #{timestamp}'")
         logger.error "Unable to make git commit: #{$CHILD_STATUS}"
         failures += 1
       end

--- a/templates/pe_nc_backup.epp
+++ b/templates/pe_nc_backup.epp
@@ -51,7 +51,7 @@ logger.level = log_level
 logger_stdout = Logger.new(STDOUT)
 logger_stdout.level = log_level
 loggers = [logger]
-loggers += logger_stdout if stdout_log
+loggers << logger_stdout if stdout_log
 
 log(loggers, :info, "pe_nc_backup started at #{Time.now}")
 

--- a/templates/pe_nc_backup.epp
+++ b/templates/pe_nc_backup.epp
@@ -12,25 +12,28 @@ require 'logger'
 require 'open3'
 require 'time'
 
-def log(logger, severity, message)
-  puts "#{severity.to_s.upcase} - #{message}"
-  case severity
-  when :info
-    logger.info(message)
-  when :warn
-    logger.warn(message)
-  when :error
-    logger.error(message)
+def log(loggers, severity, message)
+  loggers.each do |logger|
+    case severity
+    when :info
+      logger.info(message)
+    when :warn
+      logger.warn(message)
+    when :error
+      logger.error(message)
+    end
   end
 end
 
 puppet_bindir = '/opt/puppetlabs/puppet/bin'
 ssldir        = '<%= $ssl_dir -%>'
 
-my_dir   = ARGV[0]
-certname = ARGV[1] || `#{puppet_bindir}/puppet config print certname`.chomp
-failures = 0
-thefile  = 'node_groups.json'
+my_dir     = ARGV[0]
+certname   = ARGV[1] || `#{puppet_bindir}/puppet config print certname`.chomp
+log_level  = ARGV[2] || '<%= $log_level %>'
+stdout_log = (ARGV[3] == 'stdout_log') || <%= $stdout_log %>
+failures  = 0
+thefile   = 'node_groups.json'
 
 unless my_dir && my_dir != ''
   puts 'No backup directory specified, using /opt/pe_nc_backup'
@@ -42,8 +45,15 @@ unless File.directory?(my_dir)
 end
 
 logfile = File.join(my_dir, 'pe_nc_backup.log')
-logger  = Logger.new(logfile, 10, 1_024_000)
-log(logger, :info, "pe_nc_backup started at #{Time.now}")
+logger = Logger.new(logfile, 10, 1_024_000)
+logger.level = log_level
+
+logger_stdout = Logger.new(STDOUT)
+logger_stdout.level = log_level
+loggers = [logger]
+loggers += logger_stdout if stdout_log
+
+log(loggers, :info, "pe_nc_backup started at #{Time.now}")
 
 repo_dir = File.join(my_dir, 'repo')
 unless File.directory?(repo_dir)
@@ -53,27 +63,27 @@ end
 
 timestamp = Time.now.iso8601
 
-log(logger, :info, "determined certname to be: #{certname}")
+log(loggers, :info, "determined certname to be: #{certname}")
 
 cmd = "#{puppet_bindir}/ncio --uri 'https://#{certname}:4433/classifier-api/v1' "
 cmd += "--cert '#{ssldir}/certs/#{certname}.pem' "
 cmd += "--key '#{ssldir}/private_keys/#{certname}.pem' "
 cmd += "backup > '#{repo_dir}/#{thefile}'"
 
-log(logger, :info, "Running command: [#{cmd}]")
+log(loggers, :info, "Running command: [#{cmd}]")
 
 Open3.popen2e(cmd) do |_stdin, stdout_err, wait_thr|
   # rubocop:disable Lint/AssignmentInCondition
   while line = stdout_err.gets
-    log(logger, :info, line)
+    log(loggers, :info, line)
   end
   # rubocop:enable Lint/AssignmentInCondition
 
   exit_status = wait_thr.value
   if exit_status.success?
-    log(logger, :info, 'Node groups backed up successfully.')
+    log(loggers, :info, 'Node groups backed up successfully.')
   else
-    log(logger, :error, "Node groups backup has failed! ncio: #{exit_status}.")
+    log(loggers, :error, "Node groups backup has failed! ncio: #{exit_status}.")
     failures += 1
   end
 end
@@ -102,15 +112,15 @@ if system('git status --porcelain')
   # TODO: if there is an origin remote, try pushing to it
 
   else
-    log(logger, :error, 'Failures encounted backing up node groups so git commit is being skipped.')
+    log(loggers, :error, 'Failures encounted backing up node groups so git commit is being skipped.')
     failures += 1
   end
 else
-  log(logger, :error, "This does not appear to be a git repo here at #{Dir.pwd}")
+  log(loggers, :error, "This does not appear to be a git repo here at #{Dir.pwd}")
   failures += 1
 end
 
-log(logger, :info, "Backup script complete at #{Time.now}")
+log(loggers, :info, "Backup script complete at #{Time.now}")
 if failures > 0
   logger.error "Errors (#{failures}) were encountered backing up Puppet Enterprise"
   exit 1


### PR DESCRIPTION
This allows the log file logging level, and the stdout logging level, to be configured independently. Also, the stdout logger can be disabled entirely if desired.

The defaults are: 

```
  Enum['debug', 'info', 'warn', 'error', 'fatal'] $log_level        = 'info',
  Enum['debug', 'info', 'warn', 'error', 'fatal'] $log_level_stdout = 'error',
  Boolean                                         $stdout_log       = true,
```

This addresses #7 

In particular cron will not generate any emails unless an error has been encountered with $log_level_stdout set to 'error'.