### PR TITLE
Cron interval

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,9 @@ Parameters:
 - `ssl_dir` - The path to the Puppet Agent's ssl directory on the master. Default: `/etc/puppetlabs/puppet/ssl`.
 - `log_level` - The verbosity of the Ruby logger writing to the log file. Possible values: 'debug', 'info', 'warn', 'error', 'fatal'. Default: `info`.
 - `log_level_stdout` - The verbosity of the Ruby logger writing to STDOUT. Possible values: 'debug', 'info', 'warn', 'error', 'fatal'. Default: `error`.
-- `stdout_log` - Whether to enable the STDOUT logger. Default: true (Boolean)
+- `stdout_log` - Whether to enable the STDOUT logger. Boolean. Default: true
+- `cron_hour` - The hour for the cron job. String. Default: `*`
+- `cron_minute` - The minute for the cron job. String. Default: `*/5` (every 5 minutes)
 
 ## Limitations
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -12,6 +12,8 @@ class pe_nc_backup (
   Enum['debug', 'info', 'warn', 'error', 'fatal'] $log_level        = 'info',
   Enum['debug', 'info', 'warn', 'error', 'fatal'] $log_level_stdout = 'error',
   Boolean                                         $stdout_log       = true,
+  String                                          $cron_hour        = '*',
+  String                                          $cron_minute      = '*/5',
 ) {
 
   $git_repo_dir = "${path}/repo"
@@ -59,8 +61,8 @@ class pe_nc_backup (
   cron { 'pe_nc_backup':
     command => "${bin_dir}/pe_nc_backup ${path}",
     user    => 'pe-puppet',
-    hour    => '*',
-    minute  => '*/5',
+    hour    => $cron_hour,
+    minute  => $cron_minute,
     require => [ File['pe_nc_backup script'], Package['ncio'], Vcsrepo[$git_repo_dir], ],
   }
 


### PR DESCRIPTION
Allows adjustment of when the backup script is executed via `$cron_hour` and `$cron_minute` parameters. Addresses #8 

This PR builds on #9 which should be reviewed first. 